### PR TITLE
Add a graphite output

### DIFF
--- a/docs/api/outputs.rst
+++ b/docs/api/outputs.rst
@@ -15,6 +15,13 @@ duct.outputs.elasticsearch
    :members:
    :show-inheritance:
 
+duct.outputs.graphite
+============================
+
+.. automodule:: duct.outputs.graphite
+   :members:
+   :show-inheritance:
+
 duct.outputs.logger
 ============================
 

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -57,7 +57,7 @@ An example logging output::
     log = logging.getLogger(__name__)
 
     class Logger(Output):
-        def eventsReceived(self, events):
+        async def eventsReceived(self, events):
             log.info("Events dequeued: %s", len(events))
 
 If you save this as `test.py` the basic configuration you need is simply ::

--- a/duct/objects.py
+++ b/duct/objects.py
@@ -108,7 +108,7 @@ class Output(object):
     async def createClient(self):
         """Coroutine that sets up the output connection"""
 
-    def eventsReceived(self, events):
+    async def eventsReceived(self, events):
         """Receives a list of events and queues them"""
         if self.maxsize > 0:
             if len(self.events) < self.maxsize:

--- a/duct/outputs/graphite.py
+++ b/duct/outputs/graphite.py
@@ -1,0 +1,71 @@
+"""
+.. module:: logger
+   :synopsis: Output which sends events to the standard logging output
+
+.. moduleauthor:: Colin Alston <colin@tamvera.com>
+"""
+import logging
+import asyncio
+
+from duct.objects import Output, Event
+
+log = logging.getLogger(__name__)
+
+
+class Graphite(Output):
+    """Graphite output.
+    By default events are named {prefix}.{hostname}.{source service} unless
+    prefix_hostname is set to False
+
+    **Configuration arguments:**
+
+    :param server: Graphite server hostname (default: localhost)
+    :type server: str.
+    :param port: Graphite server port (default: 2003)
+    :type port: int.
+    :param prefix: Metric path prefix (default: None)
+    :type prefix: str.
+    :param prefix_hostname: Whether to append the event source hostname field to
+                            the path (default: True)
+    :type prefix_hostname: bool.
+    """
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.server = self.config.get('server', 'localhost')
+        self.port = self.config.get('port', 2003)
+
+        self.prefix = self.config.get('prefix', None)
+
+        self.prefix_hostname = self.config.get('prefix_hostname', True)
+
+    async def push_batch_to_graphite(self, metrics):
+        """Sends a batch of metric lines to Graphite via a single TCP connection."""
+        try:
+            _reader, writer = await asyncio.open_connection(self.server, self.port)
+            for metric_path, value, timestamp in metrics:
+                message = f"{metric_path} {value} {timestamp}\n"
+                writer.write(message.encode())
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+        except Exception as e:
+            log.error("Failed to send batch to Graphite: %s", str(e))
+
+    async def eventsReceived(self, events:list[Event]):
+        """Called when events are routed to this output"""
+        metrics = []
+        for ev in events:
+            path = []
+
+            if self.prefix:
+                path.append(self.prefix)
+
+            if self.prefix_hostname:
+                path.append(ev.hostname)
+
+            path.append(ev.service)
+
+            metrics.append(('.'.join(path), ev.metric, int(ev.time)))
+
+        await self.push_batch_to_graphite(metrics)

--- a/duct/outputs/logger.py
+++ b/duct/outputs/logger.py
@@ -21,7 +21,7 @@ class Logger(Output):
     """
 
     def __init__(self, *a, **kw):
-        Output.__init__(self, *a, **kw)
+        super().__init__(*a, **kw)
         if self.config.get('logfile'):
             self.logfile = open(  # pylint: disable=consider-using-with
                 self.config.get('logfile'), 'at', encoding='utf-8')
@@ -32,7 +32,7 @@ class Logger(Output):
         if self.logfile:
             self.logfile.close()
 
-    def eventsReceived(self, events):
+    async def eventsReceived(self, events):
         for ev in events:
             if self.logfile:
                 self.logfile.write(repr(ev) + '\n')

--- a/duct/outputs/null.py
+++ b/duct/outputs/null.py
@@ -10,5 +10,5 @@ from duct.objects import Output
 class Null(Output):
     """Null output throws your events away
     """
-    def eventsReceived(self, events):
+    async def eventsReceived(self, events):
         return

--- a/duct/outputs/prometheus.py
+++ b/duct/outputs/prometheus.py
@@ -67,7 +67,7 @@ class Prometheus(Output):
         if self._runner:
             await self._runner.cleanup()
 
-    def eventsReceived(self, events):
+    async def eventsReceived(self, events):
         for event in events:
             metric_name = self.prefix + event.service.replace('.', '_')
             if event.attributes:

--- a/duct/outputs/riemann.py
+++ b/duct/outputs/riemann.py
@@ -158,7 +158,7 @@ class RiemannUDP(Output):
         self.protocol = await riemann.create_riemann_udp(server, port)
         log.info('Riemann UDP ready for %s:%s', server, port)
 
-    def eventsReceived(self, events):
+    async def eventsReceived(self, events):
         """Receives a list of events and transmits them to Riemann"""
         if self.protocol:
             self.protocol.sendEvents(events)

--- a/duct/service.py
+++ b/duct/service.py
@@ -214,8 +214,7 @@ class DuctService(object):
                 log.debug("Sending events %s to %s", events, route)
 
             for output in self.outputs[route]:
-                asyncio.get_event_loop().call_soon(
-                    output.eventsReceived, events)
+                asyncio.ensure_future(output.eventsReceived(events))
 
     def sendEvent(self, source, events):
         """Callback that all event sources call when they have new events"""

--- a/duct/tests/test_duct.py
+++ b/duct/tests/test_duct.py
@@ -13,16 +13,16 @@ from duct.tests import globs
 
 
 class TestConfig:
-    def test_config_parser(self):
-        if not os.path.exists('testdir'):
-            os.mkdir('testdir')
-        with open('testdir/test.yaml', 'wt') as f:
+    def test_config_parser(self, tmp_path):
+        if not os.path.exists(tmp_path/'testdir'):
+            os.mkdir(tmp_path/'testdir')
+        with open(tmp_path/'testdir/test.yaml', 'wt') as f:
             f.write(globs.CONFIG_INCLUDE)
 
-        with open('testconf.yaml', 'wt') as f:
-            f.write(globs.CONFIG_TEST)
+        with open(tmp_path/'testconf.yaml', 'wt') as f:
+            f.write(globs.CONFIG_TEST.replace('testdir', str(tmp_path/'testdir')))
 
-        c = ConfigFile('testconf.yaml')
+        c = ConfigFile(str(tmp_path/'testconf.yaml'))
 
         merged = c.get('mergehash')
         assert merged['test3']['foo'] == 'bar'

--- a/duct/tests/test_logs.py
+++ b/duct/tests/test_logs.py
@@ -6,62 +6,62 @@ from duct.logs import follower, parsers
 
 
 class TestLogs:
-    def test_logfollow(self):
+    def test_logfollow(self, tmp_path):
         try:
-            os.unlink('test.log.lf')
-            os.unlink('test.log')
+            os.unlink(tmp_path/'test.log.lf')
+            os.unlink(tmp_path/'test.log')
         except Exception:
             pass
 
-        log = open('test.log', 'wt')
-        log.write('foo\nbar\n')
-        log.flush()
+        with open(tmp_path/'test.log', 'wt') as log:
+            log.write('foo\nbar\n')
+            log.flush()
 
-        f = follower.LogFollower('test.log', tmp_path=".", history=True)
+            f = follower.LogFollower(str(tmp_path/'test.log'), tmp_path=tmp_path, history=True)
 
-        r = f.get()
+            r = f.get()
 
-        log.write('test')
-        log.flush()
+            log.write('test')
+            log.flush()
 
-        r2 = f.get()
+            r2 = f.get()
 
-        log.write('ing\n')
-        log.flush()
+            log.write('ing\n')
+            log.flush()
 
-        r3 = f.get()
+            r3 = f.get()
 
-        assert r[0] == 'foo'
-        assert r[1] == 'bar'
+            assert r[0] == 'foo'
+            assert r[1] == 'bar'
 
-        assert r2 == []
-        assert r3[0] == 'testing'
+            assert r2 == []
+            assert r3[0] == 'testing'
 
-        log.close()
+        
 
         # Move inode
-        os.rename('test.log', 'testold.log')
+        os.rename(tmp_path/'test.log', tmp_path/'testold.log')
 
-        log = open('test.log', 'wt')
-        log.write('foo2\nbar2\n')
-        log.close()
+        with open(tmp_path/'test.log', 'wt') as log:
+            log.write('foo2\nbar2\n')
+            log.close()
 
-        r = f.get()
+            r = f.get()
 
-        assert r[0] == 'foo2'
-        assert r[1] == 'bar2'
+            assert r[0] == 'foo2'
+            assert r[1] == 'bar2'
 
-        # Go backwards
-        log = open('test.log', 'wt')
-        log.write('foo3\n')
-        log.close()
+            # Go backwards
+            log = open(tmp_path/'test.log', 'wt')
+            log.write('foo3\n')
+            log.close()
 
-        r = f.get()
+            r = f.get()
 
-        assert r[0] == 'foo3'
+            assert r[0] == 'foo3'
 
-        os.unlink('test.log')
-        os.unlink('testold.log')
+        os.unlink(tmp_path/'test.log')
+        os.unlink(tmp_path/'testold.log')
 
     def test_apache_parser(self):
         log = parsers.ApacheLogParser('combined')

--- a/duct/tests/test_outputs.py
+++ b/duct/tests/test_outputs.py
@@ -39,7 +39,7 @@ class TestOutputs:
         await out.createClient()
         out.client._request = _fake_request
 
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         meta, metric = last_request['args'][1].strip('\n').split('\n')
@@ -59,13 +59,72 @@ class TestOutputs:
         await out.createClient()
         out.client._request = _fake_request
 
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         request_data = json.loads(last_request['args'][1])[0]
 
         assert request_data['metric'] == 'sky'
 
+    @pytest.mark.asyncio
+    async def test_graphite_output(self, event):
+        service = DuctService(TestConfig({
+            "outputs":[
+                {"output":"duct.outputs.graphite.Graphite"}
+            ]
+        }))
+
+        async def push_batch_to_graphite(m):
+            assert m[0][0] == "testhost.sky"
+
+        await service.startService()
+        try:
+            output = service.outputs[None][0]
+        
+            output.push_batch_to_graphite = push_batch_to_graphite
+            await output.eventsReceived([event])
+        finally:
+            await service.stopService()
+
+    @pytest.mark.asyncio
+    async def test_graphite_output_prefix(self, event):
+        service = DuctService(TestConfig({
+            "outputs":[
+                {"output":"duct.outputs.graphite.Graphite", "prefix": "foo"}
+            ]
+        }))
+
+        async def push_batch_to_graphite(m):
+            assert m[0][0] == "foo.testhost.sky"
+
+        await service.startService()
+        try:
+            output = service.outputs[None][0]
+        
+            output.push_batch_to_graphite = push_batch_to_graphite
+            await output.eventsReceived([event])
+        finally:
+            await service.stopService()
+
+    @pytest.mark.asyncio
+    async def test_graphite_output_prefix_no_host(self, event):
+        service = DuctService(TestConfig({
+            "outputs":[
+                {"output":"duct.outputs.graphite.Graphite", "prefix": "foo", "prefix_hostname": False}
+            ]
+        }))
+
+        async def push_batch_to_graphite(m):
+            assert m[0][0] == "foo.sky"
+
+        await service.startService()
+        try:
+            output = service.outputs[None][0]
+        
+            output.push_batch_to_graphite = push_batch_to_graphite
+            await output.eventsReceived([event])
+        finally:
+            await service.stopService()
 
 class TestNATSOutput:
     @pytest.mark.asyncio
@@ -73,7 +132,7 @@ class TestNATSOutput:
         nats_mod.nats = FakeNATS()
         out = nats_mod.Nats({}, service)
         await out.createClient()
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         topic, payload = out.nc.messages[0]
@@ -91,7 +150,7 @@ class TestNATSOutput:
         nats_mod.nats = FakeNATS()
         out = nats_mod.Nats({}, service)
         await out.createClient()
-        out.eventsReceived([ev])
+        await out.eventsReceived([ev])
         await out._tick()
 
         _, payload = out.nc.messages[0]
@@ -108,7 +167,7 @@ class TestNATSOutput:
         nats_mod.nats = FakeNATS()
         out = nats_mod.Nats({"format": "senml-cbor"}, service)
         await out.createClient()
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         topic, payload = out.nc.messages[0]
@@ -124,7 +183,7 @@ class TestNATSOutput:
         nats_mod.nats = FakeNATS()
         out = nats_mod.Nats({"format": "json"}, service)
         await out.createClient()
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         topic, payload = out.nc.messages[0]
@@ -140,7 +199,7 @@ class TestNATSOutput:
         nats_mod.nats = FakeNATS()
         out = nats_mod.Nats({"prefix": "metrics"}, service)
         await out.createClient()
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         topic, _ = out.nc.messages[0]
@@ -152,7 +211,7 @@ class TestNATSOutput:
         nats_mod.nats = FakeNATS()
         out = nats_mod.Nats({}, service)
         await out.createClient()
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         topic, _ = out.nc.messages[0]
@@ -165,7 +224,7 @@ class TestNATSOutput:
         await out.createClient()
         assert out.js is not None
 
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         await out._tick()
 
         assert len(out.nc.messages) == 1
@@ -188,7 +247,7 @@ class TestNATSOutput:
         out.nc = fake
         out.js = None
         out.use_jetstream = False
-        out.eventsReceived([event])
+        await out.eventsReceived([event])
         # Should not raise
         await out.sendEvents(out.events)
 

--- a/duct/tests/test_service.py
+++ b/duct/tests/test_service.py
@@ -93,7 +93,7 @@ class FakeOutput(Output):
         Output.__init__(self, *a)
         self.events = None
 
-    def eventsReceived(self, events):
+    async def eventsReceived(self, events):
         self.events = events
 
 

--- a/duct/tests/test_ssh.py
+++ b/duct/tests/test_ssh.py
@@ -59,13 +59,13 @@ class TestSSH:
             'use_ssh': True,
         }, self._qb, FakeDuct())
 
-    def test_ssh_add_keyfile(self):
-        with open('temp_key', 'wt') as f:
+    def test_ssh_add_keyfile(self, tmp_path):
+        with open(tmp_path/'temp_key', 'wt') as f:
             f.write(testKey)
 
         basic.LoadAverage({
             'service': 'mem',
             'use_ssh': True,
-            'ssh_keyfile': 'temp_key',
+            'ssh_keyfile': str(tmp_path/'temp_key'),
             'ssh_key': None,
         }, self._qb, FakeDuct())

--- a/duct/tests/test_utils.py
+++ b/duct/tests/test_utils.py
@@ -4,13 +4,14 @@ from duct import utils
 
 
 class TestUtils:
-    def test_persistent_cache(self):
-        pc = utils.PersistentCache(location='test.cache')
+    def test_persistent_cache(self, tmp_path):
+        loc = str(tmp_path/'cache')
+        pc = utils.PersistentCache(location=loc)
 
         pc.set('foo', 'bar')
         pc.set('bar', 'baz')
 
-        pc2 = utils.PersistentCache(location='test.cache')
+        pc2 = utils.PersistentCache(location=loc)
 
         assert pc2.get('foo')[1] == 'bar'
 


### PR DESCRIPTION
also refactor outputs to have an async event pipeline, then the whole output doesn't need to be written as an independent queue task